### PR TITLE
Add get_sites and get_sysinfo helpers

### DIFF
--- a/pyunifi/controller.py
+++ b/pyunifi/controller.py
@@ -222,6 +222,24 @@ class Controller(object):
 
         return self._read(self.api_url + 'list/usergroup')
 
+    def get_sysinfo(self):
+        """Return basic system informations."""
+
+        return self._read(self.api_url + 'stat/sysinfo')
+
+    def get_sites(self):
+        """Return a list of all sites,
+        with their UID and description"""
+
+        if(self.version == 'v2'):
+            return None
+        elif(self.version == 'v3'):
+            js = json.dumps({'cmd': 'get-sites'})
+            params = urllib.urlencode({'json': js})
+            return self._read(self.api_url + 'cmd/sitemgr', params)
+        else:
+            return self._read(self.url + 'api/self/sites')
+
     def get_wlan_conf(self):
         """Return a list of configured WLANs
         with their configuration parameters.

--- a/pyunifi/controller.py
+++ b/pyunifi/controller.py
@@ -230,15 +230,8 @@ class Controller(object):
     def get_sites(self):
         """Return a list of all sites,
         with their UID and description"""
-
-        if(self.version == 'v2'):
-            return None
-        elif(self.version == 'v3'):
-            js = json.dumps({'cmd': 'get-sites'})
-            params = urllib.urlencode({'json': js})
-            return self._read(self.api_url + 'cmd/sitemgr', params)
-        else:
-            return self._read(self.url + 'api/self/sites')
+        
+        return self._read(self.url + 'api/self/sites')
 
     def get_wlan_conf(self):
         """Return a list of configured WLANs


### PR DESCRIPTION
I've added these two helpers to retrieve sites and sysinfo.

_get_sites_ helpers have already been proposed as a PR but was a little to intrusive in every functions.
I've just reused existing code from @uJIu4 : https://github.com/calmh/unifi-api/pull/39#issuecomment-231037978

_get_sysinfo_ is usefull to retrieve Unifi controller name/FQDN and Unifi controller version, etc.

Many usefull API functions from php class [UniFi-API-browser](https://github.com/malle-pietje/UniFi-API-browser) could be backported to python