### PR TITLE
Make Controller._login more robust to failure cases.

### DIFF
--- a/pyunifi/controller.py
+++ b/pyunifi/controller.py
@@ -152,9 +152,9 @@ class Controller(object):
                 if r.status_code is not 200:
                     raise APIError("Login failed - status code: %i" % r.status_code)
                 return
-            except urllib3.exceptions.ProtocolError as pe:
+            except:
                 continue
-        raise APIError("Login failed - ProtocolErrors: %s" % str(pe))
+        raise APIError("Login failed - Unknown Errors")
 
     def _logout(self):
         log.debug('logout()')


### PR DESCRIPTION
Added the ability for Controller._login to kind of recover from urllib3 ProtocolErrors by simply retrying the login Controller.MAX_LOGIN_RETRIES times.