### PR TITLE
No ssl warning

### DIFF
--- a/pyunifi/controller.py
+++ b/pyunifi/controller.py
@@ -3,7 +3,6 @@ import logging
 import requests
 import shutil
 import time
-import urllib.parse
 import warnings
 
 

--- a/pyunifi/controller.py
+++ b/pyunifi/controller.py
@@ -80,7 +80,7 @@ class Controller(object):
         self.ssl_verify = ssl_verify
 
         if ssl_verify is False:
-            warnings.simplefilter("default", category=requests.packages.
+            warnings.simplefilter("ignore", category=requests.packages.
                                   urllib3.exceptions.InsecureRequestWarning)
 
         self.session = requests.Session()


### PR DESCRIPTION
Removes import of urllib.parse.  This import fails on the debian stretch systems using this module and it doesn't appear to be used in the code anyway.

Don't print the below error when ssl_verify=False.
/usr/lib/python2.7/dist-packages/urllib3/connectionpool.py:845: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
