### PR TITLE
Add new method to update user group bandwidth.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,14 @@ Return a list of all known clients, with significant information about each.
 
 Return a list of user groups with its rate limiting settings.
 
+### `update_user_group(self, group_id, down_kbps=-1, up_kbps=-1)`
+
+Update user group bandwidth settings.
+
+- `group_id` -- Group ID to modify.
+- `down_kbps` -- New bandwidth in KBPS for download.
+- `up_kbps` -- New bandwidth in KBPS for upload.
+
 ### `get_wlan_conf(self)`
 
 Return a list of configured WLANs with their configuration parameters.

--- a/pyunifi/controller.py
+++ b/pyunifi/controller.py
@@ -460,7 +460,7 @@ class Controller(object):
         for sect, setting in settings.items():
             res.extend(self._api_write('set/setting/' + sect, setting))
         return res
-        
+
     def update_user_group(self, group_id, down_kbps=-1, up_kbps=-1):
         """
         Update user group bandwidth settings
@@ -484,5 +484,5 @@ class Controller(object):
                     "site_id": self.site_id
                 })
                 return res
-        
+
         raise ValueError("Group ID {0} is not valid.".format(group_id))


### PR DESCRIPTION
Also implements _api_update() method to all PUT calls.

Let me know if you would rather not check the user group ID prior to sending the PUT request. I'm good with it either way.