### PR TITLE
Add method to set the client alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,11 @@ Unauthorize a guest based on his MAC address.
 
   - `guest_mac` -- the guest MAC address : aa:bb:cc:dd:ee:ff
 
+### `set_client_alias(self, mac, alias)`
+Set client alias. Use "" to reset to the default.
+  - mac: The target MAC: aa:bb:cc:dd:ee:ff
+  - alias: The alias to set
+
 Utilities
 ---------
 

--- a/pyunifi/controller.py
+++ b/pyunifi/controller.py
@@ -487,11 +487,11 @@ class Controller(object):
 
         raise ValueError("Group ID {0} is not valid.".format(group_id))
 
-    def set_client_alias(self,mac,alias):
+    def set_client_alias(self, mac, alias):
         """
         Set the client alias. Set to "" to reset to default
         :param mac: The MAC of the client to rename
         :param alias: The alias to set
         """
         client = self.get_client(mac)['_id']
-        return self._api_update('rest/user/' + client,{'name': alias})
+        return self._api_update('rest/user/' + client, {'name': alias})

--- a/pyunifi/controller.py
+++ b/pyunifi/controller.py
@@ -486,3 +486,12 @@ class Controller(object):
                 return res
 
         raise ValueError("Group ID {0} is not valid.".format(group_id))
+
+    def set_client_alias(self,mac,alias):
+        """
+        Set the client alias. Set to "" to reset to default
+        :param mac: The MAC of the client to rename
+        :param alias: The alias to set
+        """
+        client = self.get_client(mac)['_id']
+        return self._api_update('rest/user/' + client,{'name': alias})


### PR DESCRIPTION
Sets the client alias in the same way that's done in the UI. I need to make one extra API call to resolve MAC to Client ID - if there's a better way, let me know.