### PR TITLE
Increase ls-clients reliability

### DIFF
--- a/unifi-ls-clients
+++ b/unifi-ls-clients
@@ -17,19 +17,19 @@ args = parser.parse_args()
 c = Controller(args.controller, args.username, args.password, args.port, args.version, args.siteid, ssl_verify=(not args.no_ssl_verify))
 
 aps = c.get_aps()
-ap_names = dict([(ap['mac'], ap.get('name')) for ap in aps])
+ap_names = dict([(ap['mac'], ap.get('name', '????')) for ap in aps])
 clients = c.get_clients()
-clients.sort(key=lambda x: -x['rssi'])
+clients.sort(key=lambda x: -x.get('rssi', 100))
 
 FORMAT = '%-16s  %18s  %-12s  %4s  %4s  %3s  %3s'
 print(FORMAT % ('NAME', 'MAC', 'AP', 'CHAN', 'RSSI', 'RX', 'TX'))
 for client in clients:
-    ap_name = ap_names[client['ap_mac']]
-    name = client.get('hostname') or client.get('ip', 'Unknown')
-    rssi = client['rssi']
-    mac = client['mac']
-    rx = int(client['rx_rate'] / 1000)
-    tx = int(client['tx_rate'] / 1000)
-    channel = client['channel']
+    ap_name = ap_names.get(client.get('ap_mac', '????'), '????')
+    name = client.get('hostname') or client.get('ip', '????')
+    rssi = client.get('rssi', 100)
+    mac = client.get('mac', '????')
+    rx = int(client.get('rx_rate', 0) / 1000)
+    tx = int(client.get('tx_rate', 0) / 1000)
+    channel = client.get('channel','????')
 
     print(FORMAT % (name, mac, ap_name, channel, rssi, rx, tx))

--- a/unifi-ls-clients
+++ b/unifi-ls-clients
@@ -26,7 +26,7 @@ print(FORMAT % ('NAME', 'MAC', 'AP', 'CHAN', 'RSSI', 'RX', 'TX'))
 for client in clients:
     ap_name = ap_names.get(client.get('ap_mac', '????'), '????')
     name = client.get('hostname') or client.get('ip', '????')
-    rssi = client.get('rssi', 100)
+    rssi = client.get('rssi', '????')
     mac = client.get('mac', '????')
     rx = int(client.get('rx_rate', 0) / 1000)
     tx = int(client.get('tx_rate', 0) / 1000)


### PR DESCRIPTION
In multiple cases the keys we are looking for will not exist. For example, wired clients will not have AP, channel, or RSSI values. Pending associations are not guaranteed to have all three of these fields added atomically. 

One fix would be to hide these types of errors by building a nice 'Client' class and then programming the scripts to a stable, guaranteed interface. An effective stopgap is to do what I'm going with in this commit - to just use `.get` with some sane default instead of allowing a `KeyError` exception to happen when the keys do not exist