### PR TITLE
Fix statistics

### DIFF
--- a/pyunifi/controller.py
+++ b/pyunifi/controller.py
@@ -165,7 +165,7 @@ class Controller(object):
 
     def get_statistics_last_24h(self):
         """Returns statistical data of the last 24h"""
-        return self.get_statistics_24h(time())
+        return self.get_statistics_24h(time.time())
 
     def get_statistics_24h(self, endtime):
         """Return statistical data last 24h from time"""


### PR DESCRIPTION
Time module can't be called directly. it needs to be time.time() or some other format. not the module itself.